### PR TITLE
Standardize log names & levels

### DIFF
--- a/ryan/bot.py
+++ b/ryan/bot.py
@@ -8,7 +8,6 @@ from discord.ext import commands
 from ryan.database import Database
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class Ryan(commands.Bot):

--- a/ryan/bot.py
+++ b/ryan/bot.py
@@ -7,7 +7,7 @@ from discord.ext import commands
 
 from ryan.database import Database
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 class Ryan(commands.Bot):
@@ -31,7 +31,7 @@ class Ryan(commands.Bot):
         This reduces having to log in cog module setups.
         """
         super().add_cog(cog)
-        logger.info(f"Cog loaded: {cog.qualified_name}")
+        log.info(f"Cog loaded: {cog.qualified_name}")
 
     async def start(self, *args, **kwargs) -> None:
         """Prepare Bot subclass.
@@ -44,7 +44,7 @@ class Ryan(commands.Bot):
 
         await super().start(*args, **kwargs)
 
-        logger.info("Bot online")
+        log.info("Bot online")
 
     async def close(self) -> None:
         """Allow base class to close, then safely close database connection and http session."""

--- a/ryan/database.py
+++ b/ryan/database.py
@@ -6,7 +6,7 @@ from typing import List
 
 import aiosqlite
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 class Database:
@@ -38,7 +38,7 @@ class Database:
         Returns `self` to allow method chaining.
         """
         self._connection = await aiosqlite.connect(self.DB_FILE, isolation_level=None)
-        logger.info("Database connection open")
+        log.info("Database connection open")
 
         await self._connection.execute(
             f"""
@@ -57,7 +57,7 @@ class Database:
 
         Gives an empty list should no nicknames be available.
         """
-        logger.debug("Database received call to `get_nicknames`")
+        log.debug("Database received call to `get_nicknames`")
         cursor = await self._connection.execute(
             f"""SELECT "{self.C_AUTHOR}", "{self.C_TARGET}", "{self.C_NAME}" FROM "{self.T_NICKNAMES}";"""
         )
@@ -66,7 +66,7 @@ class Database:
 
     async def add_nickname(self, author: int, target: int, name: str) -> None:
         """Add a new nickname for `target` from `author` with a value of `name`."""
-        logger.debug(f"Database received call to `add_nickname` (author={author}, target={target}, name={name})")
+        log.debug(f"Database received call to `add_nickname` (author={author}, target={target}, name={name})")
         await self._connection.execute(
             f"""INSERT INTO "{self.T_NICKNAMES}" VALUES (?, ?, ?);""",
             (author, target, name),
@@ -74,7 +74,7 @@ class Database:
 
     async def remove_nickname(self, name: str) -> None:
         """Remove rows with a name of `name`."""
-        logger.debug(f"Database received call to `remove_nickname` (name={name})")
+        log.debug(f"Database received call to `remove_nickname` (name={name})")
         await self._connection.execute(
             f"""DELETE FROM "{self.T_NICKNAMES}" WHERE "{self.C_NAME}" = ?;""",
             (name,)
@@ -82,7 +82,7 @@ class Database:
 
     async def truncate_nicknames(self) -> None:
         """Truncate the entire nicknames table."""
-        logger.debug("Database received call to `truncate_nicknames`")
+        log.debug("Database received call to `truncate_nicknames`")
         await self._connection.execute(
             f"""DELETE FROM "{self.T_NICKNAMES}";"""
         )
@@ -90,4 +90,4 @@ class Database:
     async def close(self) -> None:
         """Safely close the database connection from an asynchronous context."""
         await self._connection.close()
-        logger.info("Database connection safely closed")
+        log.info("Database connection safely closed")

--- a/ryan/database.py
+++ b/ryan/database.py
@@ -7,7 +7,6 @@ from typing import List
 import aiosqlite
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
 
 
 class Database:

--- a/ryan/exts/gallonmate.py
+++ b/ryan/exts/gallonmate.py
@@ -14,7 +14,6 @@ from ryan.constants import Channels, Emoji, Guilds, Users
 from ryan.utils import msg_error, msg_success, relay_message
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 def is_gallonmate(user: discord.User) -> bool:

--- a/ryan/exts/gallonmate.py
+++ b/ryan/exts/gallonmate.py
@@ -13,7 +13,7 @@ from ryan.bot import Ryan
 from ryan.constants import Channels, Emoji, Guilds, Users
 from ryan.utils import msg_error, msg_success, relay_message
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def is_gallonmate(user: discord.User) -> bool:
@@ -78,7 +78,7 @@ class Gallonmate(commands.Cog):
     async def switch_daemon_func(self) -> None:
         """Background task calling `switch_routine` once a day."""
         await self.bot.wait_until_ready()
-        logger.info("Daemon started")
+        log.info("Daemon started")
 
         while True:
             t_sleep = await seconds_until_midnight()
@@ -87,9 +87,9 @@ class Gallonmate(commands.Cog):
             try:
                 old_name, new_name = await self.switch_routine()
             except SwitchException as switch_exc:
-                logger.error(f"Daily switch failed: {switch_exc}")
+                log.error(f"Daily switch failed: {switch_exc}")
             else:
-                logger.info("Daily switch successful")
+                log.info("Daily switch successful")
 
                 if self.announce:
                     msg = (

--- a/ryan/exts/seasons.py
+++ b/ryan/exts/seasons.py
@@ -8,7 +8,7 @@ from discord.ext import commands
 from ryan.bot import Ryan
 from ryan.constants import Emoji
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 RESET_SEASON = "reset"  # Controls the name of the `reset` season
 

--- a/ryan/exts/seasons.py
+++ b/ryan/exts/seasons.py
@@ -9,7 +9,6 @@ from ryan.bot import Ryan
 from ryan.constants import Emoji
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 RESET_SEASON = "reset"  # Controls the name of the `reset` season
 


### PR DESCRIPTION
All logger instances are now named `log` and log levels are controlled globally, not per-module.