### PR TITLE
Standardize docstring style across project

### DIFF
--- a/ryan/bot.py
+++ b/ryan/bot.py
@@ -16,7 +16,8 @@ class Ryan(commands.Bot):
     database: Database
 
     def __init__(self, *args, **kwargs) -> None:
-        """Prepare an aiohttp session for the bot to use.
+        """
+        Prepare an aiohttp session for the bot to use.
 
         All args and kwargs propagate to super.
         """
@@ -26,7 +27,8 @@ class Ryan(commands.Bot):
         )
 
     def add_cog(self, cog: commands.Cog) -> None:
-        """Delegate to super, log successful loads.
+        """
+        Delegate to super, log successful loads.
 
         This reduces having to log in cog module setups.
         """
@@ -34,7 +36,8 @@ class Ryan(commands.Bot):
         log.info(f"Cog loaded: {cog.qualified_name}")
 
     async def start(self, *args, **kwargs) -> None:
-        """Prepare Bot subclass.
+        """
+        Prepare Bot subclass.
 
         We establish a connection to the database here from an async context,
         then delegate to the base class.

--- a/ryan/database.py
+++ b/ryan/database.py
@@ -10,7 +10,8 @@ log = logging.getLogger(__name__)
 
 
 class Database:
-    """Provides a simple API for the internal `_connection` to an SQLIte database.
+    """
+    Provides a simple API for the internal `_connection` to an SQLIte database.
 
     Ideally the database is only interfaced with through an instance of this class.
     """
@@ -31,7 +32,8 @@ class Database:
         return self.DB_FILE.stat().st_size
 
     async def open(self) -> Database:
-        """Open a connection to the database from an asynchronous context.
+        """
+        Open a connection to the database from an asynchronous context.
 
         Creates necessary tables if they don't exist.
 
@@ -53,7 +55,8 @@ class Database:
         return self
 
     async def get_nicknames(self) -> List[str]:
-        """Retrieve a list of all nicknames.
+        """
+        Retrieve a list of all nicknames.
 
         Gives an empty list should no nicknames be available.
         """

--- a/ryan/exts/gallonmate.py
+++ b/ryan/exts/gallonmate.py
@@ -22,7 +22,8 @@ def is_gallonmate(user: discord.User) -> bool:
 
 
 async def seconds_until_midnight() -> float:
-    """Give the amount of seconds needed to wait until the next-up midnight.
+    """
+    Give the amount of seconds needed to wait until the next-up midnight.
 
     The exact `midnight` moment is actually delayed to 5 seconds after, in order
     to avoid potential race conditions due to imprecise sleep.
@@ -35,7 +36,8 @@ async def seconds_until_midnight() -> float:
 
 
 async def get_help(group: commands.Group, failed_cmd: bool) -> discord.Embed:
-    """Provide an embed with commands of `group`.
+    """
+    Provide an embed with commands of `group`.
 
     If `failed_cmd` is True, the embed is coloured orange. Green otherwise.
     """
@@ -102,7 +104,8 @@ class Gallonmate(commands.Cog):
                     await ann_channel.send(embed=msg_success(msg))
 
     async def switch_routine(self) -> Tuple[str, str]:
-        """Routine to attempt to switch Gallonmate nickname.
+        """
+        Routine to attempt to switch Gallonmate nickname.
 
         If the method fails at any point, it will raise SwitchException with an informative
         message the can be displayed to the user.

--- a/ryan/exts/seasons.py
+++ b/ryan/exts/seasons.py
@@ -52,7 +52,8 @@ seasons = {
 
 
 def decorate_name(discord_name: str, season_name: str) -> str:
-    """Decorate a given string with emoji for current season.
+    """
+    Decorate a given string with emoji for current season.
 
     The used emoji are drawn randomly from the season given by `season_name`.
     Strips all other emoji from `discord_name` before decorating.
@@ -71,7 +72,8 @@ def decorate_name(discord_name: str, season_name: str) -> str:
 
 
 class Seasons(commands.Cog):
-    """Decorates the server for various seasons.
+    """
+    Decorates the server for various seasons.
 
     The guild name, channel names and member names will be decorated with
     emoji that are pre-defined for each season.
@@ -97,7 +99,8 @@ class Seasons(commands.Cog):
 
     @commands.command()
     async def season(self, ctx: commands.Context, *, season_name: str = None) -> None:
-        """Attempt to decorate the server.
+        """
+        Attempt to decorate the server.
 
         Many of the decorations may fail due to missing permissions. The bot handles
         this and returns an embed containing a report of how many decorations have


### PR DESCRIPTION
Resolves #22.

Except for single-line docstrings, summary now always goes on a new line. Both the previous and current style are PEP8-compliant, but it's good to have consistency (see issue for examples).