### PR TITLE
Use CDN-hosted coronavirus icon

### DIFF
--- a/ryan/constants.py
+++ b/ryan/constants.py
@@ -42,6 +42,7 @@ class Guilds:
 class Images:
     """Images links."""
 
+    coronavirus = "https://cdn.discordapp.com/attachments/746790524567945277/746790671557591070/coronavirus-5107715_1280.webp"  # noqa: E501
     gm_creepy = "https://cdn.discordapp.com/attachments/319955430732464128/695021552520921148/Screenshot_20200327-184350_FaceApp.jpg"  # noqa: E501
 
 

--- a/ryan/exts/corona.py
+++ b/ryan/exts/corona.py
@@ -9,13 +9,11 @@ from discord.ext import commands, tasks
 from pypopulation import get_population
 
 from ryan.bot import Ryan
-from ryan.constants import Emoji
+from ryan.constants import Emoji, Images
 from ryan.utils import msg_error, msg_success
 
 URL_API_HOME = "https://covid19api.com/"
 URL_API_DATA = "https://api.covid19api.com/summary"
-
-URL_ICON = "https://cdn.pixabay.com/photo/2020/04/29/07/54/coronavirus-5107715_1280.png"
 
 URL_FLAGS = "https://www.countryflags.io/{code}/flat/64.png"
 
@@ -218,7 +216,7 @@ class Corona(commands.Cog):
         """Create a Discord embed representation for `country`."""
         title = f"Currently active cases: `{country.active:,}` (`{country.active_ml:,}` per million)"
         embed = discord.Embed(colour=discord.Color.blurple(), timestamp=when, title=title)
-        embed.set_thumbnail(url=URL_ICON)
+        embed.set_thumbnail(url=Images.coronavirus)
         embed.set_author(name=country.name, icon_url=country.flag_url())
 
         fmt = "Total: `{total:,}`\nNew: `{new:,}`\nPer-mil: `{pml:,}`"  # Types: int, int, int


### PR DESCRIPTION
Instead of linking to a 3rd party URL, use a Discord CDN-hosted asset.