### PR TITLE
Add application-level configuration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,8 +1,5 @@
 # Discord API token goes here (mandatory)
 BOT_TOKEN=
 
-# Command invocation prefix override (optional)
-BOT_PREFIX=
-
 # Anything truthy to enable debug logs (optional)
 DEBUG=

--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,2 @@
 # Discord API token goes here (mandatory)
 BOT_TOKEN=
-
-# Anything truthy to enable debug logs (optional)
-DEBUG=

--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,2 @@
-# Discord API token goes here (mandatory)
+# Discord API token goes here where running locally.
 BOT_TOKEN=

--- a/ryan/__init__.py
+++ b/ryan/__init__.py
@@ -20,3 +20,10 @@ root_log.addHandler(handle_console)
 to_raise = ("aiosqlite", "asyncio", "db_client", "discord", "websockets")
 for log_name in to_raise:
     logging.getLogger(log_name).setLevel(logging.WARNING)
+
+# Since we do not want to miss out on logging from config init, the initial import is
+# deferred after the stdout sink is ready.
+from ryan.config import App  # noqa: E402
+
+if not App.log_debug:
+    root_log.setLevel(logging.INFO)

--- a/ryan/__main__.py
+++ b/ryan/__main__.py
@@ -5,7 +5,7 @@ import discord
 from discord.ext import commands
 
 from ryan.bot import Ryan
-from ryan.config import Secrets
+from ryan.config import App, Secrets
 
 revision = environ.get("REVISION")
 
@@ -13,7 +13,7 @@ intents = discord.Intents.default()
 intents.members = True
 
 bot = Ryan(
-    command_prefix=Secrets.bot_prefix,
+    command_prefix=App.prefix,
     activity=discord.Game(f"version {revision}"),
     help_command=None,
     intents=intents,

--- a/ryan/config/__init__.py
+++ b/ryan/config/__init__.py
@@ -1,4 +1,4 @@
-from ryan.config.constants import Channels, Emoji, Guilds, Images, Users
+from ryan.config.constants import App, Channels, Emoji, Guilds, Images, Users
 from ryan.config.secrets import Secrets
 
-__all__ = ["Channels", "Emoji", "Guilds", "Images", "Users", "Secrets"]
+__all__ = ["App", "Channels", "Emoji", "Guilds", "Images", "Users", "Secrets"]

--- a/ryan/config/constants.py
+++ b/ryan/config/constants.py
@@ -58,6 +58,16 @@ class _ConfigBase:
             setattr(self, attr_name, section[attr_name])
 
 
+class _App(_ConfigBase):
+    """Configuration for the application itself."""
+
+    prefix: str  # Command prefix on Discord.
+    log_debug: bool  # Enable DEBUG logs, otherwise INFO and above.
+
+
+App = _App(section_name="app")
+
+
 class _Channels(_ConfigBase):
     """Discord channel IDs."""
 

--- a/ryan/config/constants.py
+++ b/ryan/config/constants.py
@@ -7,7 +7,7 @@ log = logging.getLogger(__name__)
 environments = Path("ryan", "config", "environments")
 available_files = {file.name: file for file in environments.glob("*.json")}
 
-for option in ("production.json", "development.json"):
+for option in ("development.json", "production.json"):
     if option in available_files:
         chosen_file: Path = available_files[option]
         break

--- a/ryan/config/environments/production.json
+++ b/ryan/config/environments/production.json
@@ -1,4 +1,8 @@
 {
+    "app": {
+        "prefix": "?",
+        "log_debug": false
+    },
     "channels": {
         "gallonmate_rolls": 484118447073132574,
         "gallonmate_announce": 319955430732464128

--- a/ryan/config/secrets.py
+++ b/ryan/config/secrets.py
@@ -8,7 +8,6 @@ class _Secrets:
     """Runtime abstraction exposing environment variables."""
 
     bot_token: str  # Discord login token
-    bot_prefix: str  # Command prefix
 
     def __init__(self) -> None:
         """Load secrets from environment & set as attributes."""
@@ -19,7 +18,6 @@ class _Secrets:
             raise Exception(f"Environment lacks required variables: {required_keys}")
 
         self.bot_token = str(environ.get("BOT_TOKEN"))
-        self.bot_prefix = str(environ.get("BOT_PREFIX", "?"))
 
 
 Secrets = _Secrets()

--- a/ryan/config/secrets.py
+++ b/ryan/config/secrets.py
@@ -13,11 +13,13 @@ class _Secrets:
         """Load secrets from environment & set as attributes."""
         log.info("Loading secrets from environment")
 
-        required_keys = ("BOT_TOKEN",)
-        if any(key not in environ.keys() for key in required_keys):
-            raise Exception(f"Environment lacks required variables: {required_keys}")
+        for attr_name in self.__annotations__:
+            lookup_name = attr_name.upper()  # Conventionally environment variables are uppercase.
 
-        self.bot_token = str(environ.get("BOT_TOKEN"))
+            if lookup_name not in environ:
+                raise RuntimeError(f"Environment variable missing: '{lookup_name}'")
+
+            setattr(self, attr_name, environ[lookup_name])
 
 
 Secrets = _Secrets()


### PR DESCRIPTION
Previously, some app meta config was being set using env vars because we didn't have a better way to override production settings locally. With the new config abstraction added in #59, this is now possible (and more convenient). The env vars are therefore removed in this PR.